### PR TITLE
Added endpoint for updating all gcm_id's

### DIFF
--- a/routes/api/gcm.js
+++ b/routes/api/gcm.js
@@ -1,0 +1,26 @@
+var async = require('async'),
+	keystone = require('keystone'),
+	restUtils = require('./restUtils'),
+	express = require('express'),
+	router = express.Router();
+	
+var User = keystone.list("User");
+var Passenger = keystone.list("Passenger");
+var Ride = keystone.list("Ride");
+
+router.route('/')
+	.post(function(req, res, next) {
+
+		User.model.update({gcmId:req.body.old}, {gcmId:req.body.new}, null, function(err, numAffected){
+			if(err) return res.status(400).send(err);
+		})
+		Ride.model.update({gcm_id:req.body.old}, {gcm_id:req.body.new}, null, function(err, numAffected){
+			if(err) return res.status(400).send(err);
+		})
+		Passenger.model.update({gcm_id:req.body.old}, {gcm_id:req.body.new}, null, function(err, numAffected){
+			if(err) return res.status(400).send(err);
+		})
+
+		return res.status(200).send({success: true});
+	});
+module.exports = router;

--- a/routes/index.js
+++ b/routes/index.js
@@ -42,6 +42,7 @@ var users = require('./api/user');
 var ministries = require('./api/ministry');
 var summermissions = require('./api/summermission');
 var notifications = require('./api/notification');
+var gcm = require('./api/gcm');
 
 // Common Middleware
 keystone.pre('routes', middleware.initLocals);
@@ -125,4 +126,5 @@ exports = module.exports = function(app) {
 	app.use('/api/ministries', ministries);
 	app.use('/api/summermissions', summermissions);
 	app.use('/api/notifications', notifications);
+	app.use('/api/gcm', gcm);
 };


### PR DESCRIPTION
POST on `/api/gcm`; expected body: `{ old: <OLD_ID>, new: <NEW_ID> }`. Goes through all matching `User`, `Ride`, and `Passenger` documents and updates them.

Endpoint is up for discussion as is the payload.
