### PR TITLE
Proper async calls

### DIFF
--- a/routes/api/gcm.js
+++ b/routes/api/gcm.js
@@ -13,14 +13,19 @@ router.route('/')
 
 		User.model.update({gcmId:req.body.old}, {gcmId:req.body.new}, null, function(err, numAffected){
 			if(err) return res.status(400).send(err);
+			else
+			{
+				Ride.model.update({gcm_id:req.body.old}, {gcm_id:req.body.new}, null, function(err, numAffected){
+					if(err) return res.status(400).send(err);
+					else
+					{
+						Passenger.model.update({gcm_id:req.body.old}, {gcm_id:req.body.new}, null, function(err, numAffected){
+							if(err) return res.status(400).send(err);
+							else return res.status(200).send({success: true});
+						})
+					}
+				})
+			}
 		})
-		Ride.model.update({gcm_id:req.body.old}, {gcm_id:req.body.new}, null, function(err, numAffected){
-			if(err) return res.status(400).send(err);
-		})
-		Passenger.model.update({gcm_id:req.body.old}, {gcm_id:req.body.new}, null, function(err, numAffected){
-			if(err) return res.status(400).send(err);
-		})
-
-		return res.status(200).send({success: true});
 	});
 module.exports = router;


### PR DESCRIPTION
`POST /api/gcm/` was incorrect; it performed 3 async calls in series without checking their return values and then proceeded to return `200` carelessly. This change only returns `200` if all 3 calls succeed and `400` otherwise.

It is left up to the client to retry appropriately.
